### PR TITLE
Retain NFS volumes by default + fixes

### DIFF
--- a/pkg/stub/providers/nfs.go
+++ b/pkg/stub/providers/nfs.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,7 +35,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
-				"ReadWriteOnce",
+				v1.ReadWriteOnce,
 			},
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
@@ -143,7 +144,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 				},
 			},
 			Strategy: v1beta1.DeploymentStrategy{
-				Type: "Recreate",
+				Type: v1beta1.RecreateDeploymentStrategyType,
 			},
 		},
 	})
@@ -152,6 +153,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 		return err
 	}
 	logrus.Info("Creating new StorageClass for Nfs provisioner..")
+	reclaimPolicy := v1.PersistentVolumeReclaimRetain
 	sdk.Create(&storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StorageClass",
@@ -163,7 +165,8 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 				ownerRef,
 			},
 		},
-		Provisioner: "banzaicloud.com/nfs",
+		ReclaimPolicy: &reclaimPolicy,
+		Provisioner:   "banzaicloud.com/nfs",
 	})
 	if err != nil {
 		logrus.Errorf("Error happened during creating the StorageClass for Nfs %s", err.Error())

--- a/pkg/stub/providers/nfs.go
+++ b/pkg/stub/providers/nfs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
@@ -44,7 +45,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 			},
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Errorf("Error happened during creating a PersistentVolumeClaim for Nfs %s", err.Error())
 		return err
 	}
@@ -76,13 +77,13 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 			},
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Errorf("Error happened during creating the Service for Nfs %s", err.Error())
 		return err
 	}
 	logrus.Info("Creating new Deployment for Nfs provisioner..")
 	replicas := int32(1)
-	sdk.Create(&v1beta1.Deployment{
+	err = sdk.Create(&v1beta1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "extensions/v1beta1",
@@ -148,13 +149,13 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 			},
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Errorf("Error happened during creating the Deployment for Nfs %s", err.Error())
 		return err
 	}
 	logrus.Info("Creating new StorageClass for Nfs provisioner..")
 	reclaimPolicy := v1.PersistentVolumeReclaimRetain
-	sdk.Create(&storagev1.StorageClass{
+	err = sdk.Create(&storagev1.StorageClass{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StorageClass",
 			APIVersion: "storage.k8s.io/v1",
@@ -168,7 +169,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 		ReclaimPolicy: &reclaimPolicy,
 		Provisioner:   "banzaicloud.com/nfs",
 	})
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Errorf("Error happened during creating the StorageClass for Nfs %s", err.Error())
 		return err
 	}

--- a/pkg/stub/providers/nfs.go
+++ b/pkg/stub/providers/nfs.go
@@ -114,7 +114,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 					Containers: []v1.Container{
 						{
 							Name:  "nfs-provisioner",
-							Image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8",
+							Image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9",
 							Ports: []v1.ContainerPort{
 								{Name: "nfs", ContainerPort: 2049},
 								{Name: "mountd", ContainerPort: 20048},


### PR DESCRIPTION
- `Retain` reclaim policy is required by the Drone workspace concept: http://docs.drone.io/workspace/ (the provisioner version we used was broken from this perspective, so I bumped it).
- There were some error handling fixes as well.
- Trying to detect AlreadyExists errors, so race conditions don't hurt anymore, for example during parallel Drone builds.
- Fixes: #18 
- Fixes: #19