### PR TITLE
nfs-provisioner: reduce cpu requirement

### DIFF
--- a/pkg/stub/providers/nfs.go
+++ b/pkg/stub/providers/nfs.go
@@ -159,7 +159,7 @@ func SetUpNfsProvisioner(pv *v1.PersistentVolumeClaim) error {
 								{Name: volumeName, MountPath: "/export"},
 							},
 							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+								Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("250m")},
 							},
 						},
 					},


### PR DESCRIPTION
the old value of 1 was much over the real requirement, and was not
usable on small clusters