### PR TITLE
Fix bad link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The NFS StorageClass solution is based on the [Kubernetes external-storages](htt
 
 #### 5. Why this project exists?
 
-Here at [Banzai Cloud](https://banzaicloud.com) we try to automate everything so you don't have to. If you need to provision a Kubernetes cluster please check out [Pipeline](github.com/banzaicloud/pipeline). If you already have one, but you are struggling to find and configure the right `Persistent Storage` for your need then this project is for you. 
+Here at [Banzai Cloud](https://banzaicloud.com) we try to automate everything so you don't have to. If you need to provision a Kubernetes cluster please check out [Pipeline](https://github.com/banzaicloud/pipeline). If you already have one, but you are struggling to find and configure the right `Persistent Storage` for your need then this project is for you. 
 
 #### 6. What's next for this project for the near future?
 


### PR DESCRIPTION
Without the protocol included, this url was being treated as relative to this project rather than being an absolute URL, so it'd attempt to load `https://github.com/banzaicloud/pvc-operator/blob/master/github.com/banzaicloud/pipeline` instead of the correct URL.