### PR TITLE
Rename storage account

### DIFF
--- a/pkg/stub/providers/azure.go
+++ b/pkg/stub/providers/azure.go
@@ -170,7 +170,7 @@ func (az *AzureProvider) determineParameters(pvc *v1.PersistentVolumeClaim) (map
 		case "ReadWriteMany", "ReadOnlyMany":
 			loc := az.metadata.location
 			parameter[location] = loc
-			parameter[storageAccount] = "banzaicloudtest"
+			parameter[storageAccount] = "banzaicloudpvcop"
 			parameter[skuName] = "Standard_LRS"
 			return parameter, nil
 		}


### PR DESCRIPTION
Storage account names must be between 3 and 24 characters in length and may contain numbers and lowercase letters only.
Your storage account name must be unique within Azure. No two storage accounts can have the same name.